### PR TITLE
Updated javadoc of getTile method

### DIFF
--- a/src/Rack.java
+++ b/src/Rack.java
@@ -79,7 +79,7 @@ public class Rack {
     }
 
     /**
-     * The hasTile method returns the tile from the rack that corresponds
+     * The getTile method returns the tile from the rack that corresponds
      * to the specified letter. If no matching tile was found, the method returns null.
      * @author Pathum Danthanarayana, 101181411
      *


### PR DESCRIPTION
Updated the javadoc of the getTile method (replaced 'hasTile' with 'getTile').